### PR TITLE
Prepare win state

### DIFF
--- a/tests/game.js
+++ b/tests/game.js
@@ -179,3 +179,9 @@ test('ending a turn draws a new hand and recycles discard pile', t => {
 	t.is(state.discardPile.length, 0)
 })
 
+test.todo('when monster reaches 0 hp, you win!', t => {
+	const {state} = t.context
+	t.is(state.monster.currentHealth, 42)
+	const newState = a.changeHealth(state, {target: 'monster', amount: -42})
+	t.is(newState.monster.currentHealth, 0)
+})


### PR DESCRIPTION
Currently there is no real win state. Let's make one. When a monster goes to or below 0 hp, what happens?

Maybe a new "win screen" with stats and a button to play again.