### PR TITLE
Fix win screen

### DIFF
--- a/public/game/utils.js
+++ b/public/game/utils.js
@@ -28,12 +28,18 @@ export function shuffle(array) {
 	return array
 }
 
+// Generate a range of numbers like range(3) === [1,2,3] or range(3, 6) === [6,7,8]
+export function range(size, startAt = 0) {
+	return [...Array(size).keys()].map((i) => i + startAt)
+}
+
 // Returns the current room in a dungeon.
 export function getCurrRoom(state) {
 	return state.dungeon.rooms[state.dungeon.index || 0]
 }
 
-// Support a target like "enemyx", where x is the order of the monster.
+// Returns an array of targets (player or monsters)
+// "target" can be "player", "enemyx" (where x is the index) or "all enemies"
 export function getTargets(state, target) {
 	if (target.startsWith('player')) {
 		return [state.player]
@@ -74,9 +80,4 @@ export function isCurrentRoomCompleted(state) {
 export function isDungeonCompleted(state) {
 	const clearedRooms = state.dungeon.rooms.map(isRoomCompleted).filter(Boolean)
 	return clearedRooms.length === state.dungeon.rooms.length
-}
-
-// Use it to generate a range of numbers like range(3) === [1,2,3] or range(3, 6) === [6,7,8]
-export function range(size, startAt = 0) {
-	return [...Array(size).keys()].map((i) => i + startAt)
 }

--- a/public/game/utils.js
+++ b/public/game/utils.js
@@ -53,10 +53,7 @@ export function getTargets(state, target) {
 	throw new Error(`Can not find monster with target: "${target}"`)
 }
 
-// Check if the current room in a game has been cleared.
-export function isCurrentRoomCompleted(state) {
-	const room = getCurrRoom(state)
-
+export function isRoomCompleted(room) {
 	if (room.type === 'monster') {
 		const deadMonsters = room.monsters.filter((m) => m.currentHealth < 1)
 		return deadMonsters.length === room.monsters.length
@@ -65,6 +62,18 @@ export function isCurrentRoomCompleted(state) {
 	if (room.type === 'campfire') {
 		// @todo
 	}
+}
+
+// Check if the current room in a game has been cleared.
+export function isCurrentRoomCompleted(state) {
+	const room = getCurrRoom(state)
+	return isRoomCompleted(room)
+}
+
+// Checks if the whole dungeon (all rooms) has been cleared.
+export function isDungeonCompleted(state) {
+	const clearedRooms = state.dungeon.rooms.map(isRoomCompleted).filter(Boolean)
+	return clearedRooms.length === state.dungeon.rooms.length
 }
 
 // Use it to generate a range of numbers like range(3) === [1,2,3] or range(3, 6) === [6,7,8]

--- a/public/ui/app.js
+++ b/public/ui/app.js
@@ -5,7 +5,7 @@ import {html, Component} from '../../web_modules/htm/preact/standalone.module.js
 import createNewGame from '../game/index.js'
 // import ActionManager from '../game/action-manager.js'
 // import actions from './../game/actions.js'
-import {getCurrRoom, isCurrentRoomCompleted} from '../game/utils.js'
+import {getCurrRoom, isCurrentRoomCompleted, isDungeonCompleted} from '../game/utils.js'
 import {getRandomCards} from './../game/cards.js'
 
 // Components
@@ -103,7 +103,9 @@ export default class App extends Component {
 	render(props, state) {
 		const isDead = state.player.currentHealth < 1
 		const didWin = isCurrentRoomCompleted(state)
+		const didWinGame = isDungeonCompleted(state)
 		const room = getCurrRoom(state)
+
 		return html`
 			<${DragDrop} key=${state.dungeon.index} onAdd=${this.playCard}>
 				<div class="App" tabindex="0" onKeyDown=${(e) => this.handleShortcuts(e)}>
@@ -112,7 +114,11 @@ export default class App extends Component {
 						<p>You are dead.</p>
 						<button onclick=${() => this.props.onLoose()}>Try again?</button>
 					<//> `}
-					${didWin &&
+					${didWinGame &&
+					html`<${Overlay}>
+						<p center><button onclick=${() => this.props.onWin()}>You win!</button></p>
+					<//> `}
+					${!didWinGame && didWin &&
 					html`<${Overlay}>
 						<${Rewards} cards=${getRandomCards()} rewardWith=${this.handlePlayerReward} />
 						<p center><button onclick=${() => this.goToNextRoom()}>Go to next room</button></p>

--- a/tests/dungeon.js
+++ b/tests/dungeon.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import actions from '../public/game/actions'
 import Dungeon, {CampfireRoom, MonsterRoom, Monster} from '../public/game/dungeon'
-import {getCurrRoom, isCurrentRoomCompleted} from '../public/game/utils'
+import {getCurrRoom, isCurrentRoomCompleted, isDungeonCompleted} from '../public/game/utils'
 
 const a = actions
 
@@ -34,6 +34,18 @@ test('we know when a monster room is won', (t) => {
 	t.false(isCurrentRoomCompleted(state))
 	room.monsters[0].currentHealth = 0
 	t.true(isCurrentRoomCompleted(state))
+})
+
+test('we know when the entire dungeon has been cleared', (t) => {
+	const dungeon = Dungeon({
+		rooms: [MonsterRoom(Monster()), MonsterRoom(Monster())],
+	})
+	const state = {dungeon}
+	t.false(isDungeonCompleted(state))
+	state.dungeon.rooms[0].monsters[0].currentHealth = 0
+	t.false(isDungeonCompleted(state))
+	state.dungeon.rooms[1].monsters[0].currentHealth = 0
+	t.true(isDungeonCompleted(state))
 })
 
 test('we know when a monster room with many monsters is won', (t) => {


### PR DESCRIPTION
We have a `didWin` variable that indicates whether you've cleared the current room. What we don't have, is a way to see if you cleared the whole dungeon.

This PR adds that.

A new `didWinGame` var + `isDungeonCleared` utility function.

The naming could be much better....