### PR TITLE
An example of additional conditions (DONT merge before fixing the cards properties)

### DIFF
--- a/public/game/cards.js
+++ b/public/game/cards.js
@@ -18,6 +18,13 @@ export const cards = [
 		type: 'Attack',
 		energy: 1,
 		target: 'enemy',
+		conditions: [
+			{
+				action: 'ATLEAST',
+				amount: 2,
+				type: 'Skill'
+			}
+		],
 		damage: 6,
 		description: 'Deal 6 Damage.',
 	},
@@ -27,6 +34,12 @@ export const cards = [
 		energy: 2,
 		damage: 8,
 		target: 'enemy',
+		// conditions: [
+		// 	{
+		// 		action: 'NONE',
+		// 		type: 'Skill'
+		// 	}
+		// ],
 		powers: {
 			vulnerable: 2,
 		},
@@ -140,6 +153,12 @@ export function getRandomCards(amount = 3) {
 // target = [ENEMY, ALL_ENEMY, PLAYER, NONE, SELF_AND_ENEMY, ALL]
 // this.color = [RED, GREEN, BLUE, PURPLE, COLORLESS, CURSE]
 // this.rarity = [BASIC, SPECIAL, COMMON, UNCOMMON, RARE, CURSE]
+// this.conditions = [
+// 		{
+// 			action: ['ONLY', 'NONE'],
+// 			type: this.type
+// 		}
+// ]
 //    this.card = {
 // 		name: enum,
 // 		type: enum,

--- a/public/ui/cards.js
+++ b/public/ui/cards.js
@@ -20,10 +20,29 @@ function isCardDisabled(card, currentEnergy, cards) {
 	// Should probably be a isolated function
 	else if (card.conditions && cards) {
 		card.conditions.forEach(condition => {
+
 			if (condition.action === 'ONLY') {
 				cards.forEach(card => {
 					if(card.type !== condition.type) {
 						isDisabled = true;		
+					}
+				})
+			}
+
+			if (condition.action === 'NONE') {
+				cards.forEach(card => {
+					if(card.type === condition.type) {
+						isDisabled = true;		
+					}
+				})
+			}
+
+			if (condition.action === 'ATLEAST') {
+				let amount = 0;
+				cards.forEach(card => {
+					if(card.type === condition.type) {
+						amount++
+						isDisabled = amount < condition.amount; 		
 					}
 				})
 			}


### PR DESCRIPTION
Two more examples of possible conditions.

An additional one could be "can be played only after a skill", for this we would need the previous state or a previousCard in the state. 
@oskarrough ? 

Doing that we would be heavily using the disabled attribute, am ok with that but the user might not understand why the cards are disabled. We would need a notification service informing the user when he hover/long tap  on a disabled card.

Other issue/task I see coming is that we need a way to store all the possible conditions/properties/method of a card without applying them for now.