### PR TITLE
Feat/more monsters

### DIFF
--- a/public/content/dungeon-encounters.js
+++ b/public/content/dungeon-encounters.js
@@ -1,4 +1,5 @@
 import Dungeon, {MonsterRoom, Monster} from '../game/dungeon.js'
+import gsap from '../web_modules/gsap.js'
 
 // This file contains ready-to-use dungeons filled with rooms and exciting monsters.
 
@@ -41,10 +42,17 @@ const CultistMonster = () =>
 		intents: [{weak: 1}, {damage: 6}],
 	})
 
+const RandomMonster = () =>
+	Monster({
+		random: 2,
+		hp: 36,
+		intents: [{damage: 5}, {damage: 10}, {damage: 5}],
+	})
 export const createSimpleDungeon = () => {
 	return Dungeon({
 		rooms: [
 			MonsterRoom(Monster({hp: 18, intents})),
+			MonsterRoom(RandomMonster()),
 			MonsterRoom(Monster({intents}), ScalingMonster()),
 			MonsterRoom(STSMonster()),
 			MonsterRoom(CultistMonster()),

--- a/public/content/dungeon-encounters.js
+++ b/public/content/dungeon-encounters.js
@@ -5,7 +5,7 @@ import {random} from '../game/utils.js'
 
 // Use a list of intents to describe what the monster should do each turn.
 // Supported intents: block, damage, vulnerable and weak.
-const intents = [{block: 7}, {damage: 10}, {damage: 10}]
+const intents = [{block: 7}, {damage: 10}, {damage: 8}, {}, {damage: 14}]
 
 const scalingIntents = [
 	{damage: 1},
@@ -44,9 +44,9 @@ const CultistMonster = () =>
 
 const RandomMonster = () =>
 	Monster({
+		hp: random(18, 25),
+		intents: [{damage: 5}, {damage: 10}, {damage: 5}, {damage: 12}],
 		random: 2,
-		hp: 36,
-		intents: [{damage: 5}, {damage: 10}, {damage: 5}],
 	})
 
 const TrioMonsterA = () =>
@@ -70,7 +70,7 @@ export const createSimpleDungeon = () => {
 			MonsterRoom(STSMonster()),
 			MonsterRoom(CultistMonster()),
 			MonsterRoom(Monster({hp: 24, intents}), Monster({hp: 13, intents: scalingIntents})),
-			MonsterRoom(Monster({hp: 92, intents}), Monster({intents: scalingIntents})),
+			MonsterRoom(RandomMonster({hp: 92, intents}), Monster({intents: scalingIntents})),
 			MonsterRoom(TrioMonsterB(), TrioMonsterA(), TrioMonsterB()),
 		],
 	})

--- a/public/content/dungeon-encounters.js
+++ b/public/content/dungeon-encounters.js
@@ -48,6 +48,19 @@ const RandomMonster = () =>
 		hp: 36,
 		intents: [{damage: 5}, {damage: 10}, {damage: 5}],
 	})
+
+const TrioMonsterA = () =>
+	Monster({
+		hp: gsap.utils.random(39, 46, 1),
+		intents: [{damage: 10}, {weak: 1}],
+	})
+
+const TrioMonsterB = () =>
+	Monster({
+		hp: gsap.utils.random(39, 46, 1),
+		intents: [{weak: 1}, {damage: 10}],
+	})
+
 export const createSimpleDungeon = () => {
 	return Dungeon({
 		rooms: [
@@ -58,6 +71,7 @@ export const createSimpleDungeon = () => {
 			MonsterRoom(CultistMonster()),
 			MonsterRoom(Monster({hp: 24, intents}), Monster({hp: 13, intents: scalingIntents})),
 			MonsterRoom(Monster({hp: 92, intents}), Monster({intents: scalingIntents})),
+			MonsterRoom(TrioMonsterB(), TrioMonsterA(), TrioMonsterB()),
 		],
 	})
 }

--- a/public/content/dungeon-encounters.js
+++ b/public/content/dungeon-encounters.js
@@ -1,5 +1,5 @@
 import Dungeon, {MonsterRoom, Monster} from '../game/dungeon.js'
-import gsap from '../web_modules/gsap.js'
+import {random} from '../game/utils.js'
 
 // This file contains ready-to-use dungeons filled with rooms and exciting monsters.
 
@@ -51,13 +51,13 @@ const RandomMonster = () =>
 
 const TrioMonsterA = () =>
 	Monster({
-		hp: gsap.utils.random(39, 46, 1),
+		hp: random(39, 46),
 		intents: [{damage: 10}, {weak: 1}],
 	})
 
 const TrioMonsterB = () =>
 	Monster({
-		hp: gsap.utils.random(39, 46, 1),
+		hp: random(39, 46),
 		intents: [{weak: 1}, {damage: 10}],
 	})
 

--- a/public/game/actions.js
+++ b/public/game/actions.js
@@ -1,6 +1,6 @@
 import produce from '../web_modules/immer.js'
 import {createCard} from './cards.js'
-import {shuffle, getTargets, getCurrRoom /*, range*/} from './utils.js'
+import {shuffle, getTargets, getCurrRoom} from './utils.js'
 import powers from './powers.js'
 import {createSimpleDungeon} from '../content/dungeon-encounters.js'
 
@@ -281,7 +281,6 @@ function takeMonsterTurn(state) {
 			if (intent.damage) {
 				let amount = intent.damage
 				if (monster.powers.weak) amount = powers.weak.use(amount)
-				// amount = shuffle(range(5, monster.damage - 2))[0]
 				const newHp = removeHealth(draft, {target: 'player', amount}).player.currentHealth
 				draft.player.currentHealth = newHp
 			}

--- a/public/game/dungeon.js
+++ b/public/game/dungeon.js
@@ -1,4 +1,5 @@
 import {uuid} from './utils.js'
+import {shuffle, range} from './utils.js'
 
 // A dungeon is where the adventure starts.
 export default function Dungeon(props) {
@@ -30,6 +31,19 @@ export function MonsterRoom(...monsters) {
 // A monster has health, probably some damage and a list of intents.
 // Intents are cycled through as the monster plays its turn.
 export function Monster(props = {}) {
+	let intents = props.intents
+
+	// By setting props.random to a number, all damage intents will be randomized with this range.
+	if (typeof props.random === 'number') {
+		intents = props.intents.map((intent) => {
+			if (intent.damage) {
+				let newDamage = shuffle(range(5, intent.damage - props.random))[0]
+				intent.damage = newDamage
+			}
+			return intent
+		})
+	}
+
 	return {
 		id: uuid(),
 		maxHealth: props.hp || 42,
@@ -37,7 +51,7 @@ export function Monster(props = {}) {
 		damage: props.damage || 5,
 		block: props.block || 0,
 		powers: props.powers || {},
-		intents: props.intents || [],
+		intents: intents || [],
 		nextIntent: 0,
 	}
 }

--- a/public/game/utils.js
+++ b/public/game/utils.js
@@ -36,6 +36,12 @@ export function range(size, startAt = 0) {
 	return [...Array(size).keys()].map((i) => i + startAt)
 }
 
+// Get a random number within a range
+export function random(from, to) {
+	const r = range(to - from, from)
+	return shuffle(r)[0]
+}
+
 // Returns the current room in a dungeon.
 export function getCurrRoom(state) {
 	return state.dungeon.rooms[state.dungeon.index || 0]


### PR DESCRIPTION
This PR allows monsters to define random values for health and damage intents. Adding other things should be fine as well now.

```js
Monster({
  random: 2,
  intents: [
    {damage: 10}
  ]
})
```

The damage won't be 10, but a value between 8 and 12, because of the `random` value.

Closes #50 