### PR TITLE
Upgrade ava testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "AGPL-3.0-or-later",
   "homepage": "https://slaytheweb.cards",
   "bugs": "https://github.com/oskarrough/slaytheweb/issues",
+  "type": "module",
   "scripts": {
     "start": "servor public --reload",
     "lint": "eslint public tests --fix",
@@ -15,7 +16,7 @@
     "release": "release-it"
   },
   "devDependencies": {
-    "ava": "^3.15.0",
+    "ava": "^4.3.3",
     "docco": "^0.9.1",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.2.0",
@@ -27,20 +28,10 @@
   },
   "dependencies": {
     "esm": "^3.2.25",
-    "gsap": "^3.6.0",
+    "gsap": "^3.11.0",
     "htm": "^3.1.1",
     "immer": "^9.0.15",
     "tone": "^14.8.9"
-  },
-  "ava": {
-    "require": [
-      "esm"
-    ]
-  },
-  "nyc": {
-    "require": [
-      "esm"
-    ]
   },
   "release-it": {
     "git": {

--- a/package.json
+++ b/package.json
@@ -10,18 +10,18 @@
     "lint": "eslint public tests --fix",
     "test": "ava",
     "test:watch": "ava --watch",
-    "test:coverage": "nyc ava --verbose",
+    "test:coverage": "c8 ava",
     "build": "snowpack --include 'public/**/*.js' --clean --dest 'public/web_modules' --stat --optimize",
     "docs": "rm -rf ./docs; cd public/game; docco *.js; mv docs ../../docs",
     "release": "release-it"
   },
   "devDependencies": {
     "ava": "^4.3.3",
+    "c8": "^7.12.0",
     "docco": "^0.9.1",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "nyc": "^15.1.0",
     "prettier": "2.7.1",
     "servor": "^4.0.2",
     "snowpack": "^1.7.1"

--- a/tests/actions.js
+++ b/tests/actions.js
@@ -1,9 +1,9 @@
 import test from 'ava'
-import actions from '../public/game/actions'
-import {createCard} from '../public/game/cards'
-import {MonsterRoom, Monster} from '../public/game/dungeon-rooms'
-import {createTestDungeon} from '../public/content/dungeon-encounters'
-import {getTargets, getCurrRoom, isCurrentRoomCompleted} from '../public/game/utils'
+import actions from '../public/game/actions.js'
+import {createCard} from '../public/game/cards.js'
+import {MonsterRoom, Monster} from '../public/game/dungeon-rooms.js'
+import {createTestDungeon} from '../public/content/dungeon-encounters.js'
+import {getTargets, getCurrRoom, isCurrentRoomCompleted} from '../public/game/utils.js'
 
 const a = actions
 

--- a/tests/ai.js
+++ b/tests/ai.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import actions from '../public/game/actions'
+import actions from '../public/game/actions.js'
 import Dungeon from '../public/game/dungeon.js'
 import {MonsterRoom, Monster} from '../public/game/dungeon-rooms.js'
 

--- a/tests/cards.js
+++ b/tests/cards.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import {createCard} from '../public/game/cards'
+import {createCard} from '../public/game/cards.js'
 
 test('can create an attack card', (t) => {
 	const card = createCard('Strike')

--- a/tests/dungeon.js
+++ b/tests/dungeon.js
@@ -1,10 +1,9 @@
 import test from 'ava'
-
-import {createTestDungeon} from '../public/content/dungeon-encounters'
-import actions from '../public/game/actions'
-import Dungeon from '../public/game/dungeon'
-import {MonsterRoom, Monster} from '../public/game/dungeon-rooms'
-import {getCurrRoom, isCurrentRoomCompleted, isDungeonCompleted} from '../public/game/utils'
+import {createTestDungeon} from '../public/content/dungeon-encounters.js'
+import actions from '../public/game/actions.js'
+import Dungeon from '../public/game/dungeon.js'
+import {MonsterRoom, Monster} from '../public/game/dungeon-rooms.js'
+import {getCurrRoom, isCurrentRoomCompleted, isDungeonCompleted} from '../public/game/utils.js'
 
 const a = actions
 

--- a/tests/game.js
+++ b/tests/game.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 import createNewGame from '../public/game/index.js'
-import {createCard} from '../public/game/cards'
+import {createCard} from '../public/game/cards.js'
 
 // We don't want to test too much here,
 // since tests/actions.js has most of it.

--- a/tests/powers.js
+++ b/tests/powers.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import powers from '../public/game/powers'
+import powers from '../public/game/powers.js'
 
 test('Type is either buff or debuff', (t) => {
 	t.is(powers.regen.type, 'buff')


### PR DESCRIPTION
Updates `ava` from version 3 to 4 and replaced `nyc` with `c8` for code coverage. Things got simpler!