### PR TITLE
Fix action missing card ref

### DIFF
--- a/public/game/actions.js
+++ b/public/game/actions.js
@@ -172,10 +172,10 @@ function upgradeCard(state, {card}) {
 	})
 }
 
-// The funky part of this action is the `target` argument. It needs to be a special type of string:
-// Either "player" to target yourself, or "enemyx", where "x" is the index of the monster starting from 0. See utils.js#getTargets
 /**
- *
+ * Play a card
+ * The funky part of this action is the `target` argument. It needs to be a special type of string:
+ * Either "player" to target yourself, or "enemyx", where "x" is the index of the monster starting from 0. See utils.js#getTargets
  * @param {State} state
  * @param {object} props
  * @param {object} props.card
@@ -240,11 +240,8 @@ export function useCardActions(state, {target, card}) {
 		// Make sure the action is called with a target, preferably the target you dropped the card on.
 		action.parameter.target = target
 
-		// We used to set the card here, which caused a circular JSON structure. Removing this line fixed that, but keeping this comment here for now, in case something breaks.
-		// action.parameter.card = card
-
-		// Run the action
-		newState = allActions[action.type](newState, action.parameter)
+		// Run the action (and add the `card` to the parameters
+		newState = allActions[action.type](newState, {...action.parameter, card})
 	})
 	return newState
 }
@@ -265,11 +262,10 @@ function addHealth(state, {target, amount}) {
 }
 
 function addRegenEqualToAllDamage(state, {card}) {
+	if (!card) throw new Error('missing card!')
 	return produce(state, (draft) => {
 		const room = getCurrRoom(state)
-		const aliveMonsters = room.monsters.filter((monster) => {
-			return monster.currentHealth > 0
-		})
+		const aliveMonsters = room.monsters.filter((monster) => monster.currentHealth > 0)
 		const {regen = 0} = state.player.powers
 		const totalDamage = aliveMonsters.length * card.damage
 		draft.player.powers.regen = totalDamage + regen

--- a/public/ui/app.js
+++ b/public/ui/app.js
@@ -113,10 +113,8 @@ stw.dealCards()`)
 	 * @param {HTMLElement} cardElement
 	 */
 	playCard(cardId, target, cardElement) {
-		// Play the card.
 		const card = this.state.hand.find((c) => c.id === cardId)
 		this.game.enqueue({type: 'playCard', card, target})
-
 		const supportsFlip = typeof Flip !== 'undefined'
 		let flip
 
@@ -131,7 +129,6 @@ stw.dealCards()`)
 		// Update state and re-enable dragdrop
 		this.update(() => {
 			enableDragDrop(this.base, this.playCard)
-
 			sfx.playCard({card, target})
 
 			// Animate cloned card away

--- a/tests/actions.js
+++ b/tests/actions.js
@@ -478,5 +478,12 @@ test('Clash can only be played if it is the only attack', (t) => {
 	t.is(canPlay(clash, state), false, 'can not play because non-attack card in hand')
 })
 
+test('Succube card applies regen', (t) => {
+	const {state} = t.context
+	const succube = createCard('Succube')
+	const newstate = actions.playCard(state, {card: succube, target: 'enemy0'})
+	t.is(newstate.player.powers.regen, 2)
+})
+
 test.todo('playing defend on an enemy ?')
 test.todo('can apply a power to a specific monster')


### PR DESCRIPTION
Error was caused because I removed `card` as argument to the card's action to avoid the circular json stuff.

Instead we now add the `card` as argument again, but not on the card's actions directly.

Fixes #191 