### PR TITLE
Fix being able to drop cards on dead targets

### DIFF
--- a/src/game/backend.js
+++ b/src/game/backend.js
@@ -59,12 +59,11 @@ export async function postRun(game, playerName) {
 }
 
 /**
- * @returns {Promise<Run[]>} list of game runs
+ * @returns {Promise<{runs: Run[], total: number}>} list of game runs
  */
 export async function getRuns() {
 	const res = await fetch(apiUrl)
-	const {runs} = await res.json()
-	return runs
+	return await res.json()
 }
 
 /**

--- a/src/game/utils-state.js
+++ b/src/game/utils-state.js
@@ -78,6 +78,17 @@ export function cardHasValidTarget(cardTarget, targetQuery) {
 }
 
 /**
+ * Can't even begin to explain this one. Needs refactor.
+ * @param {HTMLElement} el
+ * @returns {string}
+ */
+export function getTargetStringFromElement(el) {
+	const targetIndex = Array.from(el.parentNode.children).indexOf(el)
+	return el.dataset.type + targetIndex
+}
+
+
+/**
  * @param {Room} room
  * @returns {boolean} true if the room has been cleared.
  */

--- a/src/ui/dragdrop.js
+++ b/src/ui/dragdrop.js
@@ -36,23 +36,25 @@ export default function enableDragDrop(container, afterRelease) {
 			},
 			// While dragging, highlight any targets we are dragging over.
 			onDrag() {
+				// this.target is the card's DOM element
 				if (this.target.attributes.disabled) {
 					this.endDrag()
 				}
 				let i = targets.length
 				while (--i > -1) {
-					// Highlight only if valid target.
-					if (this.hitTest(targets[i], '40%')) {
-						if (
-							cardHasValidTarget(
-								this.target.getAttribute('data-card-target'),
-								getTargetStringFromElement(targets[i]),
-							)
-						) {
-							targets[i].classList.add(overClass)
+					const targetEl = targets[i]
+					if (this.hitTest(targetEl, '40%')) {
+						const hasValidTarget = cardHasValidTarget(
+							this.target.getAttribute('data-card-target'),
+							getTargetStringFromElement(targetEl),
+						)
+						const targetIsDead = targetEl.classList.contains('Target--isDead')
+						console.log({hasValidTarget, targetIsDead}, targetEl)
+						if (hasValidTarget && !targetIsDead) {
+							targetEl.classList.add(overClass)
 						}
 					} else {
-						targets[i].classList.remove(overClass)
+						targetEl.classList.remove(overClass)
 					}
 				}
 			},
@@ -73,7 +75,8 @@ export default function enableDragDrop(container, afterRelease) {
 
 				// If card is allowed here, trigger the callback with target, else animate back.
 				const targetString = getTargetStringFromElement(targetEl)
-				if (cardHasValidTarget(cardEl.getAttribute('data-card-target'), targetString)) {
+				const targetIsDead = targetEl.classList.contains('Target--isDead')
+				if (cardHasValidTarget(cardEl.getAttribute('data-card-target'), targetString) && !targetIsDead) {
 					afterRelease(cardEl.dataset.id, targetString, cardEl)
 				} else {
 					animateCardToHand(this)

--- a/src/ui/pages/stats.astro
+++ b/src/ui/pages/stats.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro'
 import {getRuns} from '../../game/backend.js'
 import '../styles/typography.css'
 
-const runs = (await getRuns()).reverse()
+let {runs, total} = (await getRuns())
 ---
 
 <Layout title="Statistics & Highscores">
@@ -18,7 +18,7 @@ const runs = (await getRuns()).reverse()
 
     <div class="Box Box--text Box--full">
       <p>
-        A chronological list of Slay the Web runs.<br />
+        A chronological list of <strong>{total}</strong> Slay the Web runs. Although we only show 200 latest here because I did not implement pagination and else the server timeouts..<br />
         There is quite a bit of statistics that could be gathered from the runs, and isn't yet shown here. <a
           href="https://matrix.to/#/#slaytheweb:matrix.org"
           rel="nofollow">Chat on #slaytheweb:matrix.org</a>


### PR DESCRIPTION
We simply didn't check whether targets were dead or not before dropping. But now we do, and I tried to make it a bit nicer to read this part of the code.

Resolves #239 