### PR TITLE
Remove service worker again

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,13 @@
+self.addEventListener('install', function(e) {
+	self.skipWaiting()
+})
+
+self.addEventListener('activate', function(e) {
+	self.registration.unregister()
+		.then(function() {
+			return self.clients.matchAll()
+		})
+		.then(function(clients) {
+			clients.forEach(client => client.navigate(client.url))
+		})
+});


### PR DESCRIPTION
We used to have a `sw.js`. I removed it. But it's still there on many clients since it's cached forever. This attempts to unregister it by creating a new sw with the name, that isn't referenced anywhere.